### PR TITLE
Moves the content of the introspection response to separate JWT claim…

### DIFF
--- a/draft-ietf-oauth-jwt-introspection-response.xml
+++ b/draft-ietf-oauth-jwt-introspection-response.xml
@@ -263,9 +263,8 @@ token=2YotnFZFEjr1zCsicMWpAA]]></artwork>
      </t>
 
      <t>The JWT MAY include other claims, including those from the "JSON Web Token Claims"
-     registry established by <xref target="RFC7519"/>, such as <spanx style="verb">iat</spanx>
-     to indicate when the introspection response was issued by the AS. The JWT SHOULD NOT
-     include the <spanx style="verb">sub</spanx> and <spanx style="verb">exp</spanx> claims
+     registry established by <xref target="RFC7519"/>. The JWT SHOULD NOT include the
+     <spanx style="verb">sub</spanx> and <spanx style="verb">exp</spanx> claims
      as an additional prevention against misuse of the JWT as an access token (see
      <xref target="Cross-JWT_Confusion"/>).</t>
           

--- a/draft-ietf-oauth-jwt-introspection-response.xml
+++ b/draft-ietf-oauth-jwt-introspection-response.xml
@@ -194,7 +194,7 @@
     <spanx style="verb">Accept</spanx> HTTP header "application/token-introspection+jwt"
     in the introspection request.</t>
         
-    <t>Authentication at the token introspection endpoint can utilize client authentication
+   <t>The AS SHOULD authenticate the caller of the token introspection endpoint. Authentication at can utilize client authentication methods or a separate access token issued to the resource server. </t>
     methods or a separate access token issued to the resource server. Whether a resource
     server is required to authenticate is determined by the respective RS-specific
     policy at the AS.</t>

--- a/draft-ietf-oauth-jwt-introspection-response.xml
+++ b/draft-ietf-oauth-jwt-introspection-response.xml
@@ -44,7 +44,7 @@
 <?rfc subcompact="no" ?>
 <!-- keep one blank line between list items -->
 <!-- end of list of popular I-D processing instructions -->
-<rfc category="std" docName="draft-ietf-oauth-jwt-introspection-response-08"
+<rfc category="std" docName="draft-ietf-oauth-jwt-introspection-response-09"
      ipr="trust200902">
   <!--
 		category values: std, bcp, info, exp, and historic ipr values:
@@ -85,7 +85,7 @@
       </address>
     </author>
 
-    <date day="19" month="Sep" year="2019" />
+    <date day="20" month="Mar" year="2020" />
 
     <!-- Meta-data Declarations -->
 
@@ -150,7 +150,7 @@
 </t>
     </section>
     
-    <section anchor="as-rs-relationshio" title="Resource server management">
+    <section anchor="as-rs-relationshio" title="Resource Server Management">
     <t>The authorization server (AS) and the resource server (RS) maintain a strong two-way trust relationship.
     The resource server relies on the authorization server to obtain authorization,
     user and other data as input to its access control decisions and service delivery.
@@ -190,22 +190,22 @@
 
 	<section anchor="jwt_request" title="Requesting a JWT Response">
     
-	<t>A resource server requests to receive a JWT introspection response by
-        including an Accept header with content type "application/jwt" in the
-        introspection request.</t>
+	<t>A resource server requests a JWT introspection response by including an
+    <spanx style="verb">Accept</spanx> HTTP header "application/token-introspection+jwt"
+    in the introspection request.</t>
         
     <t>Authentication at the token introspection endpoint can utilize client authentication
     methods or a separate access token issued to the resource server. Whether a resource
     server is required to authenticate is determined by the respective RS-specific
     policy at the AS.</t>
 
-      <t>The following is a non-normative example request using 
-      client authentication:</t>
+    <t>The following is a non-normative example request with client authentication:</t>
+
 	  <t>
 	  	<figure>
           <artwork><![CDATA[POST /introspect HTTP/1.1
-Host: server.example.com
-Accept: application/jwt
+Host: as.example.com
+Accept: application/token-introspection+jwt
 Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
 Content-Type: application/x-www-form-urlencoded
 
@@ -214,155 +214,154 @@ token=2YotnFZFEjr1zCsicMWpAA]]></artwork>
 	  </t>
 	  
 	  <t>If required by its policy, the authorization server MUST authenticate the 
-	  caller and check its authorization to use the token introspection 
+	  caller and validate its authorization to use the token introspection
 	  endpoint.</t>
 
 	</section>
 	
     <section anchor="jwt_response" title="JWT Response">
     
-      <t>The introspection endpoint responds with a JWT, setting the
-          "Content-Type" header to "application/jwt". This JWT is a cryptographically 
-          protected representation of the token introspection response as specified in
-          <xref target="RFC7662"/>.</t>
+     <t>The introspection endpoint responds with a JWT, setting the
+     <spanx style="verb">Content-Type</spanx> HTTP header to
+     "application/token-introspection+jwt" and the JWT <spanx style="verb">typ</spanx>
+     ("type") header to "token-introspection+jwt".</t>
+
+     <t>The JWT MUST include the following top-level claims:
+     <list hangIndent="8" style="hanging">
+         <t hangText="iss">MUST be set to the issuer URL of the authorization
+         server.</t>
+         <t hangText="aud">MUST identify the resource server receiving the token
+         introspection response.</t>
+         <t hangText="token_introspection">A JSON object containing the members
+         of the token introspection response, as specified in the "OAuth Token
+         Introspection Response" registry established by <xref target="RFC7662"/>
+         as well as other members. The separation of the introspection members into
+         a dedicated containing JWT claim is intended to prevent conflict and confusion
+         with top-level JWT claims that may bear the same name.
+         <vspace blankLines="1" />
+         If the access token is invalid, expired, revoked, or is not intended for the
+         calling resource server (audience), the authorization server MUST set the value of the
+         <spanx style="verb">active</spanx> member in the <spanx style="verb">token_introspection</spanx>
+         claim to <spanx style="verb">false</spanx>. Otherwise, the <spanx style="verb">active</spanx>
+         member is set to <spanx style="verb">true</spanx>.
+         <vspace blankLines="1" />
+         If possible, the AS MUST narrow down the <spanx style="verb">scope</spanx> value
+         to the scopes relevant to the particular RS.
+         <vspace blankLines="1" />
+         Claims from the "JSON Web Token Claims" registry that are commonly used in
+         <xref target="OpenID.Core"/> and can be applied to the resource owner MAY be included
+         as members in the <spanx style="verb">token_introspection</spanx> claim.
+         They can serve to identify the resource owner as a natural person or to
+         provide a required contact detail, such as an e-Mail address or phone number.
+         When transmitting such claims the AS acts as an identity provider in regard to
+         the RS. The AS determines based on its RS-specific policy what claims about the
+         resource owner to return in the token introspection response.
+         <vspace blankLines="1" />
+         The AS MUST ensure the release of any privacy-sensitive data is legally based.
+         <vspace blankLines="1" />
+         Further content of the introspection response is determined by the RS-specific
+         policy at the AS.</t>
+     </list>
+     </t>
+
+     <t>The JWT MAY include other claims, including those from the "JSON Web Token Claims"
+     registry established by <xref target="RFC7519"/>, such as <spanx style="verb">iat</spanx>
+     to indicate when the introspection response was issued by the AS. The JWT SHOULD NOT
+     include the <spanx style="verb">sub</spanx> and <spanx style="verb">exp</spanx> claims
+     as an additional prevention against misuse of the JWT as an access token (see
+     <xref target="Cross-JWT_Confusion"/>).</t>
           
      <t>Note: Although the JWT format is widely used as an access token format, the JWT
      returned in the introspection response is not an alternative representation of 
      the introspected access token and is not intended to be used as an access token.</t>
      
-     <t>JWT metadata values, such as <spanx style="verb">iat</spanx>, might differ between 
-     the token introspection response in JWT format and the introspected access 
-     token (see below).</t>
-     
      <t>This specification registers the "application/token-introspection+jwt" media type, 
-     which is used as value of the <spanx style="verb">typ</spanx> header parameter of the 
-     JWT to indicate that the payload is a token introspection response.</t>
+     which is used as value of the <spanx style="verb">typ</spanx> ("type") header
+     parameter of the JWT to indicate that the payload is a token introspection response.</t>
+
+     <t>The JWT is cryptographically secured as specified in <xref target="RFC7662"/>.</t>
+
+     <t>Depending on the specific resource server policy the JWT is either
+     signed, or signed and encrypted. If the JWT is signed and encrypted it
+     MUST be a Nested JWT, as defined in <xref target="RFC7519">JWT</xref>.</t>
+
+     <t>Note: If the resource server policy requires a signed and encrypted
+     response and the authorization server receives an unauthenticated request
+     containing an <spanx style="verb">Accept</spanx> header with content type other
+     than "application/token-introspection+jwt", it MUST refuse to serve the request and
+     return an HTTP status code 400. This is done to prevent downgrading attacks to
+     obtain token data intended for release to legitimate recipients only
+     (see <xref target="token_data_leakage"/>).</t>
       
-      <t>If the access token is invalid, expired, has been revoked, or is 
-      not intended to be consumed by the calling resource server (audience), the 
-      authorization server MUST set the value of the response 
-      claim <spanx style="verb">active</spanx> to <spanx style="verb">false</spanx>. 
-      Otherwise, this claim is set to <spanx style="verb">true</spanx>.</t>
-          
-      <t>If the access token is considered active, it MUST contain the claims 
-	  <spanx style="verb">iss</spanx> and <spanx style="verb">aud</spanx> in order to 
-	  prevent misuse of the JWT as an ID or access token
-	  (see <xref target="Cross-JWT_Confusion"/>).</t>
-	  
-	  <t>The <spanx style="verb">iss</spanx> MUST 
-	  be set to the issuer URL of the AS.</t> 
-	  
-	  <t>The value of the <spanx style="verb">aud</spanx> claims MUST identify 
-	  the resource server receiving the token introspection response.</t>
-	  
-	  <t>If the AS adds the following claims to the token introspection response
-	  their meaning is defined as follows:
-	  <list hangIndent="8" style="hanging">
-      	  <t hangText="iat">The <spanx style="verb">iat</spanx> claim indicates when the
-      	  introspection response was issued by the AS.</t>
-          <t hangText="exp">The <spanx style="verb">exp</spanx> claim indicates when the 
-          access token passed in the introspection request will expire.</t>
-          <t hangText="jti">The <spanx style="verb">jti</spanx> claim is a unique identifier
-          for the access token passed in the introspection request. This identifier
-          MUST be stable for all introspection calls for a given access token.</t>
-        </list>
-	  </t>
-	  
-	  <t>Further content of the introspection response is determined by the
-      RS-specific policy at the AS.</t>
-      
-      <t>If possible, the AS MUST narrow down the <spanx style="verb">scope</spanx> 
-      value to the scopes relevant to the particular RS.</t>
-      
-      <t>The JWT formatted introspection response MAY contain further claims, 
-      especially the claims defined in the "OAuth Token Introspection Response" registry 
-      established by <xref target="RFC7662"/> and the "JSON Web Token Claims" registry
-      established by <xref target="RFC7519"/>.</t>
-      
-      <t>This includes claims from the "JSON Web Token Claims" registry that are commonly used
-      in <xref target="OpenID.Core"/> and can be applied to the resource owner. These claims
-      can serve to identify the resource owner as a natural person or to provide a required
-      contact detail, such as an e-Mail address or phone number. When transmitting such claims
-      the AS acts as an identity provider in regard to the RS.</t>
-      
-      <t>The AS determines based on the RS-specific policy what claims about the resource
-      owner to return in the token introspection response. The AS MUST ensure
-      that the release of any privacy-sensitive data is legally based.</t>
-      
-      <t>The following is a non-normative example response 
-      (with line breaks for display purposes only):</t>
-	  <t>
+     <t>The following is a non-normative example response
+     (with line breaks for display purposes only):</t>
+
+	 <t>
 	  	<figure>
           <artwork><![CDATA[HTTP/1.1 200 OK
-Content-Type: application/jwt
+Content-Type: application/token-introspection+jwt
 
-eyJ0eXAiOiJ0b2tlbi1pbnRyb3NwZWN0aW9uK2p3dCIsImFsZyI6IlJTMjU2In0.eyJ
-pc3MiOiJodHRwczovL3NlcnZlci5leGFtcGxlLmNvbS8iLCJhdWQiOiJzNkJoZFJrcX
-QzIiwianRpIjoidDFGb0NDYVpkNFh2NE9SSlVXVlVlVFpmc0toVzMwQ1FDcldERGp3W
-Hk2dyIsImFjdGl2ZSI6dHJ1ZSwic2NvcGUiOiJyZWFkIHdyaXRlIGRvbHBoaW4iLCJl
-eHAiOjE1MTQ3OTc5NDIwMDAsImlhdCI6MTUxNDc5NzgyMjAwMCwiY2xpZW50X2lkIjo
-iczZCaGRSa3F0MyIsInN1YiI6Ilo1TzN1cFBDODhRckFqeDAwZGlzIiwiZ2l2ZW5fbm
-FtZSI6IkpvaG4iLCJmYW1pbHlfbmFtZSI6IkRvZSIsImJpcnRoZGF0ZSI6IjE5ODItM
-DItMDEifQ.mnGNVJJwMaMR-drVHIyjOd7S5mScHT5tYC_sLdeaS9C4pkmiOgwHNGah9
-w_15kbotjDckotJNHpNTQCcE5nRC29L_jz5hSCNTMmK62fJdEcq0QVuCL_roeHzc-s1
-bjU2V2Qme6_2468zqcuhf1fhcieWxx9bDwFFwk3su0qdoF9RBa0HobWzy1ENU6MjiKH
-vmrnd5PkJenn1rJEt0EQTUuVE0vh2tQGhxbaZkQ34mLLgES5TCuBK7ALDXhT4aGCzxg
-3jLprs_jYTjCq2kugptseKaxsvti0TxOxmxLPcuy5xRxHDUzV2h9_VWVJRgM8y0vhLN
-v9XKDe4EQqaIFLA_YD4TBeyPV7Sm4xMQ-2OsSmAz0E2BY_b_s0WrFN2K8tspQhj2mnG
-v7Zz8O3zeE2gC59JR56aU_SNspGPbt8GvTwuL5ZZTCmiWKUzQ0ev4zVthUczQmK53dx
-Zl6ZxBfIRPV5k1GTPyEPbWehizbJT4JBSLlk-l8JvJcfL2USLtJgMLH1D01fww0IqN1
-ofHeHFUmZWB_LR7kGaJ8Kx_a9z4CaaVesW8jzgSmwA8K_pv9yJqqjnUhsh51c49OAgn
-cqwAahGrUhrN0dIBrd6sRXU3AiRpaah0MMNcjR2UJbEZKwnMyHTkBQAeZAe9vO9pKV8
-JOd0ziYBpAbEpYGE4p3wog4]]></artwork>
+eyJraWQiOiJ3RzZEIiwidHlwIjoidG9rZW4taW50cm9zcGVjdGlvbitqd3QiLCJhbGc
+iOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL2FzLmV4YW1wbGUuY29tLyIsImF1ZCI6I
+mh0dHBzOi8vcnMuZXhhbXBsZS5jb20vcmVzb3VyY2UiLCJ0b2tlbl9pbnRyb3NwZWN0
+aW9uIjp7ImFjdGl2ZSI6dHJ1ZSwiaXNzIjoiaHR0cHM6Ly9hcy5leGFtcGxlLmNvbS8
+iLCJhdWQiOiJodHRwczovL3JzLmV4YW1wbGUuY29tL3Jlc291cmNlIiwiaWF0IjoxNT
+E0Nzk3ODIyLCJleHAiOjE1MTQ3OTc5NDIsImNsaWVudF9pZCI6InBhaUIyZ29vMGEiL
+CJzY29wZSI6InJlYWR3cml0ZWRvbHBoaW4iLCJzdWIiOiJaNU8zdXBQQzg4UXJBangw
+MGRpcyIsImJpcnRoZGF0ZSI6IjE5ODItMDItMDEiLCJnaXZlbl9uYW1lIjoiSm9obiI
+sImZhbWlseV9uYW1lIjoiRG9lIiwianRpIjoidDFGb0NDYVpkNFh2NE9SSlVXVlVlVF
+pmc0toVzMwQ1FDcldERGp3WHk2dyJ9fQ.d1XLA-X8Inb0kwvRkk10ZokWbpEAO6u4Vb
+0kirVPOLUdo2KiKD1IGer6bcVp-pNc2eC1yyUZGBp5GIDey8qhc41Oyhn6TOUAkLzZM
+u2vAC7j4EsTM7-pKkbWX1kmH84-vAGvLR0MNWtVUgLmmIOy9krUMXE1jd0IS_Iqk7xW
+JxmZLbuLHXx92LXRdErwThO-AHVLkiqIlz08H4LAsnKPVKMouzqBFYwK050ZJbnaVYw
+O-QRC-lhCR_8JnsLZVp-QilDeWkOJiJ46un5HKZSYwxMjkhMs_Py8GOQaQk0ZY4MGCe
+gTCKyiOsEIYSuIIDLy4YbHtY14SvZOUQwPDneFxQ]]></artwork>
         </figure>	
         </t>
         <t>
-        The example response header contains the following JSON document:
+        The example response JWT header contains the following JSON document:
         </t>
         <t>
         <figure>
           <artwork><![CDATA[{
   "typ": "token-introspection+jwt",
   "alg": "RS256"
+  "kid": "wG6D"
 }]]></artwork>
         </figure>
         </t>
         <t>
-        The example response payload contains the following JSON document:
+        The example response JWT payload contains the following JSON document:
         </t>
         <t>
         <figure>
-          <artwork><![CDATA[{  
-   "iss":"https://server.example.com/",
-   "aud":"s6BhdRkqt3",
-   "jti": "t1FoCCaZd4Xv4ORJUWVUeTZfsKhW30CQCrWDDjwXy6w",
-   "active":true,
-   "scope":"read write dolphin",
-   "exp":1514797942,
-   "iat":1514797822,
-   "client_id":"s6BhdRkqt3",
-   "sub":"Z5O3upPC88QrAjx00dis",
-   "given_name":"John",
-   "family_name":"Doe",
-   "birthdate":"1982-02-01"
+          <artwork><![CDATA[{
+  "iss":"https://as.example.com/",
+  "aud":"https://rs.example.com/resource",
+  "token_introspection":
+     {
+        "active":true,
+        "iss":"https://as.example.com/",
+        "aud":"https://rs.example.com/resource",
+        "iat":1514797822,
+        "exp":1514797942,
+        "client_id":"paiB2goo0a",
+        "scope":"read write dolphin",
+        "sub":"Z5O3upPC88QrAjx00dis",
+        "birthdate":"1982-02-01",
+        "given_name":"John",
+        "family_name":"Doe",
+        "jti":"t1FoCCaZd4Xv4ORJUWVUeTZfsKhW30CQCrWDDjwXy6w"
+     }
 }]]></artwork>
         </figure>
 
-	  </t>  
-	  <t>Depending on the specific resource server policy the JWT is either
-      signed, or signed and encrypted. If the JWT is signed and encrypted it
-      MUST be a Nested JWT, as defined in <xref target="RFC7519">JWT</xref>.</t>
-	  <t>Note: If the resource server policy requires a signed and encrypted
-      response and the authorization server receives an unauthenticated request
-	  containing an Accept header with content type other than "application/jwt", it MUST
-      refuse to serve the request and return an HTTP status code 400. This is
-      done to prevent downgrading attacks to obtain token data intended for
-      release to legitimate recipients only 
-      (see <xref target="token_data_leakage"/>).</t>
+	  </t>
+
     </section>
     
     <section anchor="client_metadata" title="Client Metadata">
-      <t>The authorization server determines what algorithm to employ to
+      <t>The authorization server determines the algorithm to
       secure the JWT for a particular introspection response. This decision can
       be based on registered metadata parameters for the resource server,
       supplied via dynamic client registration <xref target="RFC7591"/> with the 
@@ -440,30 +439,16 @@ JOd0ziYBpAbEpYGE4p3wog4]]></artwork>
     
     <section anchor="Security" title="Security Considerations">
      <section anchor="Cross-JWT_Confusion" title="Cross-JWT Confusion">
-      <t>Token introspection responses in JWT format, access tokens in JWT format, 
-      and OpenID Connect ID Tokens are syntactical similar. Attackers could try to utilize 
-      this fact and attempt to use a token introspection response as access token when 
-      invoking a resource server or as ID Token when logging into at a OpenID 
-      Connect RP.</t> 
-      
-      <t>Any relying party processing the <spanx style="verb">typ</spanx> JWT header
-      element should detect the attack since token introspection responses
-      in JWT format set this header to the value "token-introspection+jwt". 
-      Unfortunately, this is not a well established practice yet.</t>
-      
-      <t>As an alternative approach, such an attack can be prevented like 
-      any other token substitution attack by restricting the audience of the JWT.
-      As specified in <xref target="jwt_response"/>, the authorization server includes 
-      the claims <spanx style="verb">iss</spanx> and <spanx style="verb">aud</spanx> in
-      each JWT introspection response, with the <spanx style="verb">iss</spanx> 
-      value set to the authorization server's issuer URL and the 
-      <spanx style="verb">aud</spanx> value set
-      to the resource server's identifier. Any recipient of an JWT MUST check these 
-      values in order to detect substitution attacks.</t> 
-      
-      <t>OpenID Connect RPs are additionally expected to use and check
-      the <spanx style="verb">nonce</spanx> parameter and claim to prevent
-      token and code replay.</t>
+      <t>The <spanx style="verb">iss</spanx> and potentially the <spanx style="verb">aud</spanx>
+      claim of a token introspection JWT can resemble those of a JWT-encoded access token.
+      An attacker could try to exploit this and pass a JWT token introspection response as
+      an access token to the resource server. The <spanx style="verb">typ</spanx> ("type")
+      JWT header "token-introspection+jwt" and the encapsulation of the token introspection members
+      such as <spanx style="verb">sub</spanx> and <spanx style="verb">scope</spanx> in
+      the <spanx style="verb">token_introspection</spanx> claim is intended to prevent such
+      substitution attacks. Resource servers MUST therefore check the <spanx style="verb">typ</spanx>
+      JWT header value of received JWT-encoded access tokens and ensure all minimally
+      required claims for a valid access token are present.</t>
       
       <t>Resource servers MUST additionally apply the countermeasures against replay 
       as described in <xref target="I-D.ietf-oauth-security-topics"/>, section 3.2.</t>
@@ -472,7 +457,7 @@ JOd0ziYBpAbEpYGE4p3wog4]]></artwork>
            </section>
 
       <section anchor="token_data_leakage" title="Token Data Leakage">
-     <t>The authorization server MUST use Transport Layer Security (TLS) 1.2 
+      <t>The authorization server MUST use Transport Layer Security (TLS) 1.2
       (or higher) per BCP 195 <xref target="RFC7525"/> in order to prevent 
       token data leakage.</t>
       <t>To prevent introspection of leaked tokens and to present an additional
@@ -483,10 +468,10 @@ JOd0ziYBpAbEpYGE4p3wog4]]></artwork>
       <t>In the latter case, confidentiality is ensured by the fact that only
       the legitimate recipient is able to decrypt the response.
       An attacker could try to circumvent this measure by requesting a plain 
-      JSON response, using an Accept header with the content type set
-      to, for example, "application/json" instead of "application/jwt". To prevent this
+      JSON response, using an <spanx style="verb">Accept</spanx> header with the content type set
+      to, for example, "application/json" instead of "application/token-introspection+jwt". To prevent this
       attack the authorization server MUST NOT serve requests with a content type
-      other than "application/jwt" if the resource server is set up to receive 
+      other than "application/token-introspection+jwt" if the resource server is set up to receive
       encrypted responses (see also <xref target="jwt_response"/>).</t>
       </section>
 
@@ -528,7 +513,8 @@ JOd0ziYBpAbEpYGE4p3wog4]]></artwork>
     
     <section anchor="Acknowledgements" title="Acknowledgements">
       <t>We would like to thank Petteri Stenius, Neil Madden, Filip Skokan, Tony 
-      Nadalin, and Remco Schaar for their valuable feedback.</t>
+      Nadalin, Remco Schaar, Justin Richer and Takahiko Kawasaki for their valuable
+      feedback.</t>
     </section>
 
     <!-- Possibly a 'Contributors' section ... -->
@@ -678,7 +664,23 @@ JOd0ziYBpAbEpYGE4p3wog4]]></artwork>
             </list>
           </t>
         </section>
-      </section>  
+      </section>
+
+      <section anchor="ietf-jwt-IANA" title="JWT Claim Registration">
+      <t>This section registers the "token_introspection" claim in the JSON Web
+      Token (JWT) IANA registry <xref target="IANA.JWT"/> in the manner described in
+      <xref target="RFC7519"/>.</t>
+        <section title="Registry Contents">
+          <t>
+            <list style='symbols'>
+              <t>Claim name: token_introspection</t>
+              <t>Claim description: Token introspection response</t>
+              <t>Change Controller: IESG</t>
+              <t>Specification Document(s): <xref target="jwt_response"/> of [[this specification]]</t>
+            </list>
+          </t>
+        </section>
+      </section>
 
     </section>
     
@@ -752,6 +754,16 @@ JOd0ziYBpAbEpYGE4p3wog4]]></artwork>
 	</front>
 </reference>
 
+<reference anchor="IANA.JWT" target="https://www.iana.org/assignments/jwt/jwt.xhtml">
+	<front>
+	  <title>JSON Web Token (JWT)</title>
+	  <author fullname="IANA">
+	    <organization abbrev="ISO">IANA</organization>
+	  </author>
+          <date/>
+	</front>
+</reference>
+
     </references>
 
     <references title="Informative References">
@@ -768,6 +780,19 @@ JOd0ziYBpAbEpYGE4p3wog4]]></artwork>
     
     <section anchor="History" title="Document History">
       <t>[[ To be removed from the final specification ]]</t>
+
+      <t>-09<list style="symbols">
+          <t>changes the Accept and Content-Type HTTP headers from
+          "application/json" to "application/token-introspection+jwt" so they
+          match the registered media type</t>
+          <t>moves the token introspection response members into a JSON object
+          claim named "token_introspection" to provide isolation from the top-level
+          JWT-specific claims</t>
+          <t>the "sub" and "exp" claims SHOULD NOT be used as top-level JWT
+          claims as additional prevention against JWT access token substitution
+          attacks</t>
+          </list>
+      </t>
       
 	  <t>-08<list style="symbols">
           <t>made difference between introspected access token and 

--- a/draft-ietf-oauth-jwt-introspection-response.xml
+++ b/draft-ietf-oauth-jwt-introspection-response.xml
@@ -242,7 +242,7 @@ token=2YotnFZFEjr1zCsicMWpAA]]></artwork>
          If the access token is invalid, expired, revoked, or is not intended for the
          calling resource server (audience), the authorization server MUST set the value of the
          <spanx style="verb">active</spanx> member in the <spanx style="verb">token_introspection</spanx>
-         claim to <spanx style="verb">false</spanx>. Otherwise, the <spanx style="verb">active</spanx>
+         claim to <spanx style="verb">false</spanx>. The container MUST not contain any other claims in this case. Otherwise, the <spanx style="verb">active</spanx>
          member is set to <spanx style="verb">true</spanx>.
          <vspace blankLines="1" />
          If possible, the AS MUST narrow down the <spanx style="verb">scope</spanx> value

--- a/draft-ietf-oauth-jwt-introspection-response.xml
+++ b/draft-ietf-oauth-jwt-introspection-response.xml
@@ -194,10 +194,9 @@
     <spanx style="verb">Accept</spanx> HTTP header "application/token-introspection+jwt"
     in the introspection request.</t>
         
-   <t>The AS SHOULD authenticate the caller of the token introspection endpoint. Authentication at can utilize client authentication methods or a separate access token issued to the resource server. </t>
-    methods or a separate access token issued to the resource server. Whether a resource
-    server is required to authenticate is determined by the respective RS-specific
-    policy at the AS.</t>
+    <t>The AS SHOULD authenticate the caller at the token introspection endpoint.
+    Authentication can utilize client authentication methods or a separate access token issued to the resource server.
+    Whether a resource server is required to authenticate is determined by the respective RS-specific policy at the AS.</t>
 
     <t>The following is a non-normative example request with client authentication:</t>
 
@@ -212,10 +211,6 @@ Content-Type: application/x-www-form-urlencoded
 token=2YotnFZFEjr1zCsicMWpAA]]></artwork>
         </figure>
 	  </t>
-	  
-	  <t>If required by its policy, the authorization server MUST authenticate the 
-	  caller and validate its authorization to use the token introspection
-	  endpoint.</t>
 
 	</section>
 	
@@ -232,6 +227,8 @@ token=2YotnFZFEjr1zCsicMWpAA]]></artwork>
          server.</t>
          <t hangText="aud">MUST identify the resource server receiving the token
          introspection response.</t>
+         <t hangText="iat">MUST be set to the time when the introspection response
+         was created by the authorization server.</t>
          <t hangText="token_introspection">A JSON object containing the members
          of the token introspection response, as specified in the "OAuth Token
          Introspection Response" registry established by <xref target="RFC7662"/>
@@ -242,8 +239,8 @@ token=2YotnFZFEjr1zCsicMWpAA]]></artwork>
          If the access token is invalid, expired, revoked, or is not intended for the
          calling resource server (audience), the authorization server MUST set the value of the
          <spanx style="verb">active</spanx> member in the <spanx style="verb">token_introspection</spanx>
-         claim to <spanx style="verb">false</spanx>. The container MUST not contain any other claims in this case. Otherwise, the <spanx style="verb">active</spanx>
-         member is set to <spanx style="verb">true</spanx>.
+         claim to <spanx style="verb">false</spanx> and other members MUST NOT be included.
+         Otherwise, the <spanx style="verb">active</spanx> member is set to <spanx style="verb">true</spanx>.
          <vspace blankLines="1" />
          If possible, the AS MUST narrow down the <spanx style="verb">scope</spanx> value
          to the scopes relevant to the particular RS.
@@ -251,7 +248,8 @@ token=2YotnFZFEjr1zCsicMWpAA]]></artwork>
          Claims from the "JSON Web Token Claims" registry that are commonly used in
          <xref target="OpenID.Core"/> and can be applied to the resource owner MAY be included
          as members in the <spanx style="verb">token_introspection</spanx> claim.
-         They can serve to convey the privileges delegated to the client, identify the resource owner as a natural person or to
+         They can serve to convey the privileges delegated to the client,
+         to identify the resource owner as a natural person or to
          provide a required contact detail, such as an e-Mail address or phone number.
          When transmitting such claims the AS acts as an identity provider in regard to
          the RS. The AS determines based on its RS-specific policy what claims about the
@@ -788,6 +786,7 @@ gTCKyiOsEIYSuIIDLy4YbHtY14SvZOUQwPDneFxQ]]></artwork>
           <t>moves the token introspection response members into a JSON object
           claim named "token_introspection" to provide isolation from the top-level
           JWT-specific claims</t>
+          <t>"iss", "aud" and "iat" MUST be present as top-level JWT claims</t>
           <t>the "sub" and "exp" claims SHOULD NOT be used as top-level JWT
           claims as additional prevention against JWT access token substitution
           attacks</t>

--- a/draft-ietf-oauth-jwt-introspection-response.xml
+++ b/draft-ietf-oauth-jwt-introspection-response.xml
@@ -300,19 +300,19 @@ Content-Type: application/token-introspection+jwt
 
 eyJraWQiOiJ3RzZEIiwidHlwIjoidG9rZW4taW50cm9zcGVjdGlvbitqd3QiLCJhbGc
 iOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL2FzLmV4YW1wbGUuY29tLyIsImF1ZCI6I
-mh0dHBzOi8vcnMuZXhhbXBsZS5jb20vcmVzb3VyY2UiLCJ0b2tlbl9pbnRyb3NwZWN0
-aW9uIjp7ImFjdGl2ZSI6dHJ1ZSwiaXNzIjoiaHR0cHM6Ly9hcy5leGFtcGxlLmNvbS8
-iLCJhdWQiOiJodHRwczovL3JzLmV4YW1wbGUuY29tL3Jlc291cmNlIiwiaWF0IjoxNT
-E0Nzk3ODIyLCJleHAiOjE1MTQ3OTc5NDIsImNsaWVudF9pZCI6InBhaUIyZ29vMGEiL
-CJzY29wZSI6InJlYWR3cml0ZWRvbHBoaW4iLCJzdWIiOiJaNU8zdXBQQzg4UXJBangw
-MGRpcyIsImJpcnRoZGF0ZSI6IjE5ODItMDItMDEiLCJnaXZlbl9uYW1lIjoiSm9obiI
-sImZhbWlseV9uYW1lIjoiRG9lIiwianRpIjoidDFGb0NDYVpkNFh2NE9SSlVXVlVlVF
-pmc0toVzMwQ1FDcldERGp3WHk2dyJ9fQ.d1XLA-X8Inb0kwvRkk10ZokWbpEAO6u4Vb
-0kirVPOLUdo2KiKD1IGer6bcVp-pNc2eC1yyUZGBp5GIDey8qhc41Oyhn6TOUAkLzZM
-u2vAC7j4EsTM7-pKkbWX1kmH84-vAGvLR0MNWtVUgLmmIOy9krUMXE1jd0IS_Iqk7xW
-JxmZLbuLHXx92LXRdErwThO-AHVLkiqIlz08H4LAsnKPVKMouzqBFYwK050ZJbnaVYw
-O-QRC-lhCR_8JnsLZVp-QilDeWkOJiJ46un5HKZSYwxMjkhMs_Py8GOQaQk0ZY4MGCe
-gTCKyiOsEIYSuIIDLy4YbHtY14SvZOUQwPDneFxQ]]></artwork>
+mh0dHBzOi8vcnMuZXhhbXBsZS5jb20vcmVzb3VyY2UiLCJpYXQiOjE1MTQ3OTc4OTIs
+InRva2VuX2ludHJvc3BlY3Rpb24iOnsiYWN0aXZlIjp0cnVlLCJpc3MiOiJodHRwczo
+vL2FzLmV4YW1wbGUuY29tLyIsImF1ZCI6Imh0dHBzOi8vcnMuZXhhbXBsZS5jb20vcm
+Vzb3VyY2UiLCJpYXQiOjE1MTQ3OTc4MjIsImV4cCI6MTUxNDc5Nzk0MiwiY2xpZW50X
+2lkIjoicGFpQjJnb28wYSIsInNjb3BlIjoicmVhZHdyaXRlZG9scGhpbiIsInN1YiI6
+Ilo1TzN1cFBDODhRckFqeDAwZGlzIiwiYmlydGhkYXRlIjoiMTk4Mi0wMi0wMSIsImd
+pdmVuX25hbWUiOiJKb2huIiwiZmFtaWx5X25hbWUiOiJEb2UiLCJqdGkiOiJ0MUZvQ0
+NhWmQ0WHY0T1JKVVdWVWVUWmZzS2hXMzBDUUNyV0REandYeTZ3In19.przJMU5GhmNz
+vwtt1Sr-xa9xTkpiAg5IshbQsRiRVP_7eGR1GHYrNwQh84kxOkHCyje2g5WSRcYosGE
+VIiC-eoPJJ-qBwqwSlgx9JEeCDw2W5DjrblOI_N0Jvsq_dUeOyoWVMqlOydOBhKNY0s
+mBrI4NZvEExucOm9WUJXMuJtvq1gBes-0go5j4TEv9sOP9uu81gqWTr_LOo6pgT0tFF
+yZfWC4kbXPXiQ2YT6mxCiQRRNM-l9cBdF6Jx6IOrsfFhBuYdYQ_mlL19HgDDOFaleyq
+mru6lKlASOsaE8dmLSeKcX91FbG79FKN8un24iwIDCbKT9xlUFl54xWVShNDFA]]></artwork>
         </figure>	
         </t>
         <t>
@@ -335,6 +335,7 @@ gTCKyiOsEIYSuIIDLy4YbHtY14SvZOUQwPDneFxQ]]></artwork>
           <artwork><![CDATA[{
   "iss":"https://as.example.com/",
   "aud":"https://rs.example.com/resource",
+  "iat":1514797892,
   "token_introspection":
      {
         "active":true,

--- a/draft-ietf-oauth-jwt-introspection-response.xml
+++ b/draft-ietf-oauth-jwt-introspection-response.xml
@@ -251,7 +251,7 @@ token=2YotnFZFEjr1zCsicMWpAA]]></artwork>
          Claims from the "JSON Web Token Claims" registry that are commonly used in
          <xref target="OpenID.Core"/> and can be applied to the resource owner MAY be included
          as members in the <spanx style="verb">token_introspection</spanx> claim.
-         They can serve to identify the resource owner as a natural person or to
+         They can serve to convey the privileges delegated to the client, identify the resource owner as a natural person or to
          provide a required contact detail, such as an e-Mail address or phone number.
          When transmitting such claims the AS acts as an identity provider in regard to
          the RS. The AS determines based on its RS-specific policy what claims about the


### PR DESCRIPTION
…, aligns Accept and Content-Type HTTP headers with registered media type

A great side effect of moving the members to the "token_introspection" claim: it becomes now a lot more difficult to confuse the JWT with an access token, even if the RS is registered with its resource URL as client_id with the AS (as some of our customers are doing). ID token confusion becomes entirely impossible (no "sub").